### PR TITLE
ZCS-1661 Add support for publishing zip from zm-timezones repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 The `zm-timezones` package allows for frequent updating of timezone information
 without having to build and reinstall the webapps that use this information.
 The new `TzMsg*.properties` files were created by extracting the timezone
-strings from the `AjxMsg*.properties` files.  The UI team should remove the
-timezone strings from these files and update the following projects to load the
+strings from the `AjxMsg*.properties` files. Following projects are using 
 `TzMsg*.properties`:
 
 - `zm-web-client`
@@ -168,7 +167,7 @@ properties happens.  For an example previous bug, see [Bug 96974](https://bugzil
 
 This tool may help determine if any of the offsets in the main `TzMsg.properties` file are incorrect.
 
-        (cd tools && ./AjxMsgCheck.pl -t ../../timezones.ics)
+        (cd tools && ./TzMsgCheck.pl -t ../../timezones.ics)
 
 ### ZoneMatchScore section
 
@@ -229,10 +228,11 @@ they are installed to one of the standard locations, such as
 
 - `bin`
 - `conf`
-- `WebRoot`
+- `messages`
+- `js`
 
 After installation, the post-install hook should run the `deploy-timezones`
-script located in `<package-dir>/bin`.  This will copy the timezone-related
+script located in `<package-dir>/src/bin`.  This will copy the timezone-related
 files to the proper locations and set ownership and permissions appropriately.
 
 In addition, the post-install hooks for `zm-web-client` and `zm-admin-console`

--- a/build.xml
+++ b/build.xml
@@ -4,15 +4,16 @@
 
   <!-- Properties -->
   <property name="build.conf.dir" value="${build.dir}/conf"/>
-  <property name="build.web.dir" value="${build.dir}/WebRoot"/>
-  <property name="build.js.dir" value="${build.web.dir}/js"/>
-  <property name="build.webinf.dir" value="${build.web.dir}/WEB-INF"/>
   <property name="build.bin.dir" value="${build.dir}/bin"/>
   <property name="deploy.file.name" value="deploy-timezones"/>
   <property name="tz.data" value="conf/timezones.ics"/>
-  <property name="tz.dir" value="${build.js.dir}/ajax/util"/>
+  <property name="tz.dir" value="${build.dir}/js"/>
   <property name="tz.file" value="${tz.dir}/AjxTimezoneData.js"/>
-  <property name="message.dir" value="${build.webinf.dir}/classes/messages"/>
+  <property name="message.dir" value="${build.dir}/messages"/>
+
+  <target name="jar" depends="timezones" description="Creates the zip file">
+    <antcall target="zimbra-zip" />
+  </target>
 
   <!-- deploy -->
   <target name="deploy" depends="timezones" description="Deploy timezone files">
@@ -21,18 +22,27 @@
     <ant dir="${server.dir}" target="start-webserver" inheritAll="false"/>
   </target>
 
+  <path id="compile.path">
+    <path refid="class.path"/>
+    <pathelement location="${build.classes.dir}" />
+  </path>
+
   <!-- timezones -->
   <target name="timezones" depends="compile" description="generate timezone files">
-    <taskdef name="timezones" classname="com.zimbra.kabuki.tools.tz.GenerateDataTask" classpathref="test.class.path"/>
+    <taskdef name="timezones" classname="com.zimbra.kabuki.tools.tz.GenerateDataTask" classpathref="compile.path"/>
+
     <mkdir dir="${tz.dir}"/>
     <timezones src="${tz.data}" dest="${tz.file}"/>
+
     <mkdir dir="${message.dir}"/>
     <copy todir="${message.dir}">
       <fileset dir="messages" includes="*.properties" />
     </copy>
+
     <mkdir dir="${build.bin.dir}"/>
-    <copy file="bin/${deploy.file.name}" tofile="${build.bin.dir}/${deploy.file.name}"/>
+    <copy file="${src.bin.dir}/${deploy.file.name}" tofile="${build.bin.dir}/${deploy.file.name}"/>
     <chmod file="${build.bin.dir}/${deploy.file.name}" perm="a+x"/>
+
     <mkdir dir="${build.conf.dir}"/>
     <copy file="${tz.data}" todir="${build.conf.dir}"/>
   </target>

--- a/conf/tz/tools/TzMsgCheck.pl
+++ b/conf/tz/tools/TzMsgCheck.pl
@@ -7,11 +7,11 @@ use File::stat;
 use File::Copy;
 
 $sc_name              = basename("$0");
-$usage                = "usage: $sc_name -t timezones.ics [-p AjxMsg.properties]\n";
+$usage                = "usage: $sc_name -t timezones.ics [-p TzMsg.properties]\n";
 
 getopts('t:p:') or die "$usage";
 
-local $ajxprops = "../../../../zm-ajax/WebRoot/messages/AjxMsg.properties";
+local $ajxprops = "../../../messages/TzMsg.properties";
 
 die "$usage" if (!$opt_t);
 $tzics = "$opt_t";

--- a/ivy.xml
+++ b/ivy.xml
@@ -2,9 +2,12 @@
 <ivy-module version="2.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
- <info organisation="zimbra" module="zm-timezones" status="integration">
- </info>
+ <info organisation="zimbra" module="zm-timezones" status="integration" />
+ <publications>
+  <artifact name="zm-timezones" type="zip" />
+ </publications>
  <dependencies>
+  <dependency org="ant" name="ant" rev="1.6.5"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
  </dependencies>
 </ivy-module>

--- a/messages/TzMsg_ca.properties
+++ b/messages/TzMsg_ca.properties
@@ -1,0 +1,133 @@
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Web Client
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+# Timezone names
+Africa/Algiers = GMT +01:00 \u00c0frica occidental i central
+America/Asuncion = GMT -04:00 Asunci\u00f3n
+Africa/Cairo = GMT +02:00 Egipte
+Africa/Casablanca = GMT +00:00 Casablanca
+Africa/Monrovia = GMT +00:00 Monr\u00f2via
+Africa/Harare = GMT +02:00 Harare, Pret\u00f2ria
+Africa/Nairobi = GMT +03:00 Nairobi
+Africa/Windhoek = GMT +01:00 Nam\u00edbia
+America/Bogota = GMT -05:00 Col\u00f2mbia
+America/Argentina/Buenos_Aires = GMT -03:00 Argentina
+America/Cancun = GMT -05:00 Cancun, Chetumal
+America/Caracas = GMT -04:00 Caracas
+America/Cayenne = GMT -03:00 Caiena, Fortaleza
+America/Chihuahua = GMT -07:00 Chihuahua, La Paz, Mazatl\u00e1n
+America/Grand_Turk = GMT -04:00 Illes Turks i Caicos
+America/Cuiaba = GMT -04:00 Cuiab\u00e1
+America/Godthab = GMT -03:00 Groenl\u00e0ndia
+America/Guatemala = GMT -06:00 Am\u00e8rica Central
+America/Guyana = GMT -04:00 Georgetown, La Paz, Manaos, San Juan
+America/La_Paz = GMT -04:00 La Paz
+America/Manaus = GMT -04:00 Manaus
+America/Mexico_City = GMT -06:00 Guadalajara, Ciudad de M\u00e9xico, Monterrey
+America/Montevideo = GMT -03:00 Montevideo
+America/Santiago = GMT -04:00 Am\u00e8rica del Sud - Costa del Pac\u00edfic
+America/Tijuana = GMT -08:00 Baixa Calif\u00f2rnia
+Asia/Almaty = GMT +06:00 Astan\u00e0
+Asia/Amman = GMT +02:00 Jord\u00e0nia
+Asia/Baghdad = GMT +03:00 Irak
+Asia/Baku = GMT +04:00 Bak\u00fa
+Asia/Bangkok = GMT +07:00 Bangkok, Hanoi, Jakarta
+Asia/Beirut = GMT +02:00 Beirut
+Asia/Kolkata = GMT +05:30 Chennai, Calcuta, Bombai, Nova Delhi
+Asia/Kathmandu = GMT +05:45 Katmand\u00fa
+Asia/Colombo = GMT +05:30 Sri Jayawardenepura Kotte
+Asia/Damascus = GMT +02:00 Damasc
+Asia/Dhaka = GMT +06:00 Dacca
+Asia/Hong_Kong = GMT +08:00 Pequ\u00edn, Txungking, Hong Kong, \u00dcr\u00fcmqi
+Asia/Irkutsk = GMT +08:00 Irkutsk (RTZ 7)
+Asia/Jerusalem = GMT +02:00 Jerusalem
+Asia/Kabul = GMT +04:30 Kabul
+Asia/Karachi = GMT +05:00 Islamabad, Karachi
+Asia/Katmandu = GMT +05:45 Katmand\u00fa
+Asia/Krasnoyarsk = GMT +07:00 Krasnoiarsk (RTZ 6)
+Asia/Kuala_Lumpur = GMT +08:00 Kuala Lumpur
+Asia/Kuwait = GMT +03:00 Kuwait, Riad
+Asia/Magadan = GMT +11:00 Magadan
+Asia/Muscat = GMT +04:00 Abu Dhabi, Masqat
+Asia/Novosibirsk = GMT +07:00 Novosibirsk (RTZ 5)
+Asia/Rangoon = GMT +06:30 Yangon
+Asia/Seoul = GMT +09:00 Corea
+Asia/Taipei = GMT +08:00 Taipei
+Asia/Tashkent = GMT +05:00 Taixkent
+Asia/Tbilisi = GMT +04:00 Tbilissi
+Asia/Tehran = GMT +03:30 Teheran
+Asia/Tokyo = GMT +09:00 Jap\u00f3
+Asia/Ulaanbaatar = GMT +08:00 Ulan Bator
+Asia/Pyongyang = GMT +08:30 Pyongyang
+Asia/Vladivostok = GMT +10:00 Vladivostok, Magadan (RTZ 9)
+Asia/Yakutsk = GMT +09:00 Iakutsk (RTZ 8)
+Asia/Yekaterinburg = GMT +05:00 Iekaterinburg (RTZ 4)
+Asia/Yerevan = GMT +04:00 Erevan
+Atlantic/Azores = GMT -01:00 A\u00e7ores
+Atlantic/Cape_Verde = GMT -01:00 Illes Cap Verd
+Atlantic/South_Georgia = GMT -02:00 Regi\u00f3 de l\u2019Atl\u00e1ntic Central
+Australia/Adelaide = GMT +09:30 Adelaida
+Australia/Brisbane = GMT +10:00 Brisbane
+Australia/Darwin = GMT +09:30 Darwin
+Australia/Hobart = GMT +10:00 Hobart
+Australia/Perth = GMT +08:00 Perth
+Australia/Sydney = GMT +10:00 Canberra, Melbourne, Sidney
+America/Sao_Paulo = GMT -03:00 Bras\u00edlia
+America/Halifax = GMT -04:00 Hora de l\u2019Atl\u00e0ntic (Canad\u00e0)
+America/St_Johns = GMT -03:30 Terranova
+America/Regina = GMT -06:00 Saskatchewan
+Etc/GMT-12 = GMT +12:00 GMT+12
+Etc/GMT+11 = GMT -11:00 GMT-11
+Etc/GMT+12 = GMT -12:00 L\u00ednia de canvi de data
+Etc/GMT+2 = GMT -02:00 GMT-02
+UTC = GMT/UTC Temps universal coordinat
+Europe/Athens = GMT +02:00 Atenes, Beirut, Bucarest, Istanbul
+Europe/Belgrade = GMT +01:00 Belgrad, Bratislava, Budapest, Ljubljana, Praga
+Europe/Berlin = GMT +01:00 Amsterdam, Berl\u00edn, Berna, Roma, Estocolm, Viena
+Europe/Brussels = GMT +01:00 Brussel\u00b7les, Copenhague, Madrid, Par\u00eds
+Europe/Helsinki = GMT +02:00 Helsinki, K\u00edev, Riga, Sofia, Tallinn, V\u00edlnius
+Europe/Istanbul = GMT +03:00 Istanbul
+Europe/Kaliningrad = GMT +02:00 Kaliningrad (RTZ 1)
+Europe/London = GMT +00:00 Gran Bretanya, Irlanda, Portugal
+Europe/Minsk = GMT +03:00 Minsk
+Europe/Moscow = GMT +03:00 Moscou, Sant Petersburg, Volgograd (RTZ 2)
+Europe/Warsaw = GMT +01:00 Sarajevo, Skopje, Vars\u00f2via, Zagreb
+Indian/Mauritius = GMT +04:00 Port Louis
+Pacific/Auckland = GMT +12:00 Nova Zelanda
+Pacific/Fiji = GMT +12:00 Fiji
+Pacific/Guadalcanal = GMT +11:00 Salom\u00f3 / Nova Caled\u00f2nia
+Pacific/Guam = GMT +10:00 Guam, Port Moresby
+Pacific/Midway = GMT -11:00 Samoa
+Pacific/Tongatapu = GMT +13:00 Nuku\u2019alofa
+America/Anchorage = GMT -09:00 Alaska
+America/Phoenix = GMT -07:00 Arizona
+America/Chicago = GMT -06:00 EE. UU./Canad\u00e1 central
+America/Indiana/Indianapolis = GMT -05:00 Indiana (Est)
+America/New_York = GMT -05:00 EE. UU./Canad\u00e1 oriental
+Pacific/Honolulu = GMT -10:00 Hawaii
+America/Denver = GMT -07:00 Regi\u00f3 de les muntanyes d\u2019EE. UU./Canad\u00e1
+America/Fort_Nelson = GMT -07:00 Fort Nelson
+America/Los_Angeles = GMT -08:00 Regi\u00f3 del Pac\u00edfic d\u2019EE. UU./Canad\u00e1
+Europe/Samara = GMT +04:00 Izhevsk, Samara (RTZ 3)
+Europe/Bucharest = GMT +02:00 Bucarest
+America/Bahia = GMT -03:00 Salvador
+Asia/Srednekolymsk = GMT +11:00 Chokurdakh (RTZ 10)
+Pacific/Kiritimati = GMT +14:00 Illa Kiritimati
+Africa/Tripoli = GMT +02:00 Tr\u00edpoli
+Pacific/Apia = GMT +13:00 Samoa
+Asia/Kamchatka = GMT +12:00 Anadir, Petropavlovsk-Kamchatsky (RTZ 11)
+Asia/Singapore = GMT +08:00 Singapur
+Pacific/Bougainville = GMT +11:00 Hora est\u00e0ndard de Bougainville

--- a/messages/TzMsg_no.properties
+++ b/messages/TzMsg_no.properties
@@ -1,0 +1,133 @@
+# 
+# ***** BEGIN LICENSE BLOCK *****
+# Zimbra Collaboration Suite Web Client
+# Copyright (C) 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Synacor, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software Foundation,
+# version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program.
+# If not, see <https://www.gnu.org/licenses/>.
+# ***** END LICENSE BLOCK *****
+# 
+# Timezone names
+Africa/Algiers = GMT +01:00 Vestlige Sentral-Afrika
+America/Asuncion = GMT -04:00 Asuncion
+Africa/Cairo = GMT +02:00 Egypt
+Africa/Casablanca = GMT +00:00 Casablanca
+Africa/Monrovia = GMT +00:00 Monrovia
+Africa/Harare = GMT +02:00 Harare, Pretoria
+Africa/Nairobi = GMT +03:00 Nairobi
+Africa/Windhoek = GMT +01:00 Namibia
+America/Bogota = GMT -05:00 Colombia
+America/Argentina/Buenos_Aires = GMT -03:00 Argentina
+America/Cancun = GMT -05:00 Cancun, Chetumal
+America/Caracas = GMT -04:00 Caracas
+America/Cayenne = GMT -03:00 Cayenne, Fortaleza
+America/Chihuahua = GMT -07:00 Chihuahua, La Paz, Mazatlan
+America/Grand_Turk = GMT -04:00 Turks- og Caicos\u00f8yene
+America/Cuiaba = GMT -04:00 Cuiaba
+America/Godthab = GMT -03:00 Gr\u00f8nland
+America/Guatemala = GMT -06:00 Mellom-Amerika
+America/Guyana = GMT -04:00 Georgetown, La Paz, Manaus, San Juan
+America/La_Paz = GMT -04:00 La Paz
+America/Manaus = GMT -04:00 Manaus
+America/Mexico_City = GMT -06:00 Guadalajara, Mexico by, Monterrey
+America/Montevideo = GMT -03:00 Montevideo
+America/Santiago = GMT -04:00 Stillehavskysten (S\u00f8r-Amerika)
+America/Tijuana = GMT -08:00 Baja California
+Asia/Almaty = GMT +06:00 Astana
+Asia/Amman = GMT +02:00 Jordan
+Asia/Baghdad = GMT +03:00 Irak
+Asia/Baku = GMT +04:00 Baku
+Asia/Bangkok = GMT +07:00 Bangkok, Hanoi, Jakarta
+Asia/Beirut = GMT +02:00 Beirut
+Asia/Kolkata = GMT +05:30 Chennai, Kolkata, Mumbai, New Delhi
+Asia/Kathmandu = GMT +05:45 Kathmandu
+Asia/Colombo = GMT +05:30 Kotte
+Asia/Damascus = GMT +02:00 Damaskus
+Asia/Dhaka = GMT +06:00 Dhaka
+Asia/Hong_Kong = GMT +08:00 Beijing, Chongqing, Hongkong, Urumqi
+Asia/Irkutsk = GMT +08:00 Irkutsk (RTZ 7)
+Asia/Jerusalem = GMT +02:00 Jerusalem
+Asia/Kabul = GMT +04:30 Kabul
+Asia/Karachi = GMT +05:00 Islamabad, Karachi
+Asia/Katmandu = GMT +05:45 Kathmandu
+Asia/Krasnoyarsk = GMT +07:00 Krasnojarsk (RTZ 6)
+Asia/Kuala_Lumpur = GMT +08:00 Kuala Lumpur
+Asia/Kuwait = GMT +03:00 Kuwait, Riyadh
+Asia/Magadan = GMT +11:00 Magadan
+Asia/Muscat = GMT +04:00 Abu Dhabi, Muscat
+Asia/Novosibirsk = GMT +07:00 Novosibirsk (RTZ 5)
+Asia/Rangoon = GMT +06:30 Yangon
+Asia/Seoul = GMT +09:00 Korea
+Asia/Taipei = GMT +08:00 Taipei
+Asia/Tashkent = GMT +05:00 Tasjkent
+Asia/Tbilisi = GMT +04:00 Tbilisi
+Asia/Tehran = GMT +03:30 Teheran
+Asia/Tokyo = GMT +09:00 Japan
+Asia/Ulaanbaatar = GMT +08:00 Ulan Bator
+Asia/Pyongyang = GMT +08:30 Pyongyang
+Asia/Vladivostok = GMT +10:00 Vladivostok, Magadan (RTZ 9)
+Asia/Yakutsk = GMT +09:00 Jakutsk (RTZ 8)
+Asia/Yekaterinburg = GMT +05:00 Jekaterinburg (RTZ 4)
+Asia/Yerevan = GMT +04:00 Jerevan
+Atlantic/Azores = GMT -01:00 Azorene
+Atlantic/Cape_Verde = GMT -01:00 Kapp Verde
+Atlantic/South_Georgia = GMT -02:00 Midt-Atlanteren
+Australia/Adelaide = GMT +09:30 Adelaide
+Australia/Brisbane = GMT +10:00 Brisbane
+Australia/Darwin = GMT +09:30 Darwin
+Australia/Hobart = GMT +10:00 Hobart
+Australia/Perth = GMT +08:00 Perth
+Australia/Sydney = GMT +10:00 Canberra, Melbourne, Sydney
+America/Sao_Paulo = GMT -03:00 Brasilia
+America/Halifax = GMT -04:00 Atlanterhavskysten (Canada)
+America/St_Johns = GMT -03:30 Newfoundland
+America/Regina = GMT -06:00 Saskatchewan
+Etc/GMT-12 = GMT +12:00 GMT+12
+Etc/GMT+11 = GMT -11:00 GMT-11
+Etc/GMT+12 = GMT -12:00 Datolinjen
+Etc/GMT+2 = GMT -02:00 GMT-02
+UTC = GMT/UTC Coordinated Universal Time
+Europe/Athens = GMT +02:00 Aten, Beirut, Bucuresti, Istanbul
+Europe/Belgrade = GMT +01:00 Beograd, Bratislava, Budapest, Ljubljana, Praha
+Europe/Berlin = GMT +01:00 Amsterdam, Berlin, Bern, Roma, Stockholm, Wien
+Europe/Brussels = GMT +01:00 Brussel, K\u00f8benhavn, Madrid, Paris
+Europe/Helsinki = GMT +02:00 Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius
+Europe/Istanbul = GMT +03:00 Istanbul
+Europe/Kaliningrad = GMT +02:00 Kaliningrad (RTZ 1)
+Europe/London = GMT +00:00 Storbritannia, Irland, Portugal
+Europe/Minsk = GMT +03:00 Minsk
+Europe/Moscow = GMT +03:00 Moskva, St. Petersburg, Volgograd (RTZ 2)
+Europe/Warsaw = GMT +01:00 Sarajevo, Skopje, Warsawa, Zagreb
+Indian/Mauritius = GMT +04:00 Port Louis
+Pacific/Auckland = GMT +12:00 New Zealand
+Pacific/Fiji = GMT +12:00 Fiji
+Pacific/Guadalcanal = GMT +11:00 Salomon\u00f8yene / Ny-Caledonia
+Pacific/Guam = GMT +10:00 Guam, Port Moresby
+Pacific/Midway = GMT -11:00 Samoa
+Pacific/Tongatapu = GMT +13:00 Nuku'alofa
+America/Anchorage = GMT -09:00 Alaska
+America/Phoenix = GMT -07:00 Arizona
+America/Chicago = GMT -06:00 USA/Midt-Canada
+America/Indiana/Indianapolis = GMT -05:00 Indiana (\u00d8st)
+America/New_York = GMT -05:00 USA/\u00d8st-Canada
+Pacific/Honolulu = GMT -10:00 Hawaii
+America/Denver = GMT -07:00 Mountain Time (USA/Canada)
+America/Fort_Nelson = GMT -07:00 Fort Nelson
+America/Los_Angeles = GMT -08:00 Stillehavskysten (USA/Canada)
+Europe/Samara = GMT +04:00 Izjevsk, Samara (RTZ 3)
+Europe/Bucharest = GMT +02:00 Bucuresti
+America/Bahia = GMT -03:00 Salvador
+Asia/Srednekolymsk = GMT +11:00 Tsjokurdakh (RTZ 10)
+Pacific/Kiritimati = GMT +14:00 Kiritimati\u00f8ya
+Africa/Tripoli = GMT +02:00 Tripoli
+Pacific/Apia = GMT +13:00 Samoa
+Asia/Kamchatka = GMT +12:00 Anadyr, Petropavlovsk-Kamtsjatskij (RTZ 11)
+Asia/Singapore = GMT +08:00 Singapore
+Pacific/Bougainville = GMT +11:00 Bougainville, standardtid

--- a/src/bin/deploy-timezones
+++ b/src/bin/deploy-timezones
@@ -19,9 +19,8 @@
 BIN_DIR=$(dirname $0)
 BASE_DIR=$(dirname $BIN_DIR)
 CONF_DIR="${BASE_DIR}/conf"
-WR_DIR="${BASE_DIR}/WebRoot"
-JS_DIR="${WR_DIR}/js"
-WEB_INF_DIR="${WR_DIR}/WEB-INF"
+JS_DIR="${BASE_DIR}/js"
+MSG_DIR="${BASE_DIR}/messages"
 
 TZ_FILE="timezones.ics"
 TZD_FILE="AjxTimezoneData.js"
@@ -40,11 +39,11 @@ function deployApp {
     # Install WebRoot/js/ajax/util/AjxTimezoneData.js
     tzd_path="${app}/js/ajax/util/${TZD_FILE}"
     winf_path="${app}/WEB-INF/classes/messages"
-    cp "${JS_DIR}/ajax/util/${TZD_FILE}" "${tzd_path}"
+    cp "${JS_DIR}/${TZD_FILE}" "${tzd_path}"
     chmod 664 "${tzd_path}"
     chown $USER:$USER "${tzd_path}"
     # Install WebRoot/WEB-INF/classes/messages
-    cp "${WEB_INF_DIR}/classes/messages/"${PROPS_FILES} "${winf_path}/."
+    cp "${MSG_DIR}/"${PROPS_FILES} "${winf_path}/."
     chmod 664 "${winf_path}/"${PROPS_FILES}
     chown $USER:$USER "${winf_path}/"${PROPS_FILES}
 }


### PR DESCRIPTION
zm-timezones:build.xml
   - move deploy-timezones to src/bin from bin directory
   - remove structure of files which is not needed here as zm-timezones repo should not care of folder structure
   - use zimbra-zip target to publish zip
   - change ivy.xml to indicate that this project publishes a zip
   - don't use test.class.path for compiling java files as it is meant for unittests, created a new compile.path which includes java class files path

zm-timezones:/messages/
   - added TzMsg_NO.properties and TzMsg_CA.properties files, these files were missing because support for these languages were added after forking out zm-timezones repo, so copied these files from zm-ajax/WebRoot/messages/
   - Fixed some timezone offsets for above copied files as timezone.ics file is updated, this can be checked using conf/tz/tools/TzMsgCheck.pl file

zm-timezones:/conf/tz/tools
   - rename AjxMsgCheck.pl file to TzMsgCheck.pl, as now we will be checking for modifications in TzMsg.properties file not AjxMsg.properties file

zm-timezones:README.md
   - update documentation