### PR TITLE
WIP: ZCS:2486 - Separated jetty.base and jetty.home, removed jetty-<version>

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -50,9 +50,6 @@
   <target name="pkg" depends="timezones">
     <delete dir="build/dist"/>
     <delete dir="build/stage"/>
-    <exec dir="." executable="./pkg-builder.pl" failonerror="true">
-       <arg value="--define"/>
-       <arg value="jetty.distro=jetty-distribution-9.3.5.v20151012"/>
-    </exec>
+    <exec dir="." executable="./pkg-builder.pl" failonerror="true"/>
   </target>
 </project>

--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -19,9 +19,6 @@ sub parse_defines()
 {
    Die("wrong commandline options")
      if ( !GetOptions( "defines=s" => \%DEFINES ) );
-
-   Die("jetty.distro not specified (--define jetty.distro=<xxxx>)")
-     if ( !exists $DEFINES{'jetty.distro'} );
 }
 
 sub cpy_file($$)
@@ -82,8 +79,8 @@ sub stage_zimbra_timezone_data()
 
    foreach my $webapp_name ( "zimbra", "zimbraAdmin" )
    {
-      cpy_file( "build/js/AjxTimezoneData.js",           "$stage_base_dir/opt/zimbra/$DEFINES{'jetty.distro'}/webapps/$webapp_name/js/ajax/util/AjxTimezoneData.js" );
-      cpy_file( "build/messages/$_",    "$stage_base_dir/opt/zimbra/$DEFINES{'jetty.distro'}/webapps/$webapp_name/WEB-INF/classes/messages/$_" )
+      cpy_file( "build/js/AjxTimezoneData.js",           "$stage_base_dir/opt/zimbra/jetty_base/webapps/$webapp_name/js/ajax/util/AjxTimezoneData.js" );
+      cpy_file( "build/messages/$_",    "$stage_base_dir/opt/zimbra/jetty_base/webapps/$webapp_name/WEB-INF/classes/messages/$_" )
          foreach( map { basename($_); } glob("build/messages/TzMsg*.properties") );
    }
 


### PR DESCRIPTION
- Zimbra's Jetty Distribution (9.3.5.v20151012) is installed in /opt/zimbra/common/jetty_home/ via a separate package.
- Zimbra specific webapps and other custom jetty configuration files will be installed in /opt/zimbra/jetty_base/.
- Now /opt/zimbra/mailboxd and /opt/zimbra/jetty are symbolic links that point to /opt/zimbra/jetty_base/.