### PR TITLE
ZCS-12914 : Bumped up version for 10.0.0

### DIFF
--- a/pkg-builder.pl
+++ b/pkg-builder.pl
@@ -61,7 +61,7 @@ sub git_timestamp_from_dirs($)
 my %PKG_GRAPH = (
    "zimbra-timezone-data" => {
       summary    => "Zimbra Timezone Data",
-      version    => "3.0.0",
+      version    => "4.0.0",
       revision   => 1,
       hard_deps  => [],
       soft_deps  => [],


### PR DESCRIPTION
**Problem:** Getting below error while doing upgrade from 9.0 latest patch to 10.0 GA

```
zimbra-network-store
   zimbra-convertd
   zimbra-proxy
   zimbra-archiving
      ...
ERROR: Unable to install required packages
WARNING: REMOTE PACKAGE INSTALLATION FAILED.
To proceed, review the instructions at:
https://wiki.zimbra.com/wiki/Recovering_from_upgrade_failure
Failure to follow the instructions on the wiki will result in complete data loss.
[root@zqa-021 zcs-NETWORK-10.0.0_GA_4503.RHEL8_64.20230124091721]#
Log:
package zimbra-timezone-data-3.0.0.1667816334-1.r8.x86_64 (which is newer than zimbra-timezone-data-3.0.0.1667551492-1.r8.x86_64) is already installed
```
10.0.0 Package version of zimbra-timezone-data should be greater than the 9.0.0 version of zimbra-timezone-data
