### PR TITLE
ZCS-13986: Added support for Rockylinux 9 in circle-ci config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,16 @@ jobs:
          - image: zimbra/zm-base-os:devcore-ubuntu-12.04
       <<: *build_job_steps
 
+   build_c9:
+      working_directory: ~/zm-timezones
+      shell: /bin/bash -eo pipefail
+      docker:
+         - image: $DOCKER_REGISTRY/zm-base-os:devcore-centos-9
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
+      <<: *build_job_steps
+
    build_c8:
       working_directory: ~/zm-timezones
       shell: /bin/bash -eo pipefail
@@ -195,6 +205,11 @@ workflows:
          - build_u12:
             requires:
                - sanity
+         - build_c9:
+            requires:
+               - sanity
+            context:
+               - docker-dev-registry
          - build_c8:
             requires:
                - sanity
@@ -214,6 +229,7 @@ workflows:
                - build_u16
                - build_u14
                - build_u12
+               - build_c9
                - build_c8
                - build_c7
                - build_c6


### PR DESCRIPTION
**ZCS-13986: Added support for Rockylinux 9 in circle-ci config.**

- Updated the circle-ci config.yaml file with new job to build Rocky Linux 9 packages.
- Included the job into available workflows.

**Note**
- For all OS versions other than R9 we are pulling images from zimbra/ public docker image registry.
- For R9 OS version we are pulling the base image from private docker dev images registry.
- Thats why I have added the `contexts: docker-dev-registry` in the workflow.