### PR TITLE
ZCS-17472:update Java ant-1.6.5.jar for security and compatibility reasons

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -7,7 +7,7 @@
   <artifact name="zm-timezones" type="zip" />
  </publications>
  <dependencies>
-  <dependency org="ant" name="ant" rev="1.6.5"/>
+  <dependency org="org.apache.ant" name="ant" rev="1.10.15"/>
  </dependencies>
 </ivy-module>
 


### PR DESCRIPTION
Code changes to update Current Ant version which is from **ant-1.6.5.jar** to **ant-1.10.15.jar**
as per official-release notes -> https://ant.apache.org/bindownload.cgi